### PR TITLE
Fix/deprecate vttablet finalize_external_reparent_timeout parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,3 +43,6 @@ Initial release.
 # 4.3.2
 - [CHANGE] Added support for 41c356e (2020-06-04) release (minor patch)
 - [FIX] my.cnf missing `[mysqld]`
+
+# 4.3.3
+- [FIX] `finalize_external_reparent_timeout` is no longer used with vttablet

--- a/attributes/vttablet.rb
+++ b/attributes/vttablet.rb
@@ -435,9 +435,6 @@ default['vitess']['vttablet']['file_backup_storage_root'] = nil
 # file based custom rule path
 default['vitess']['vttablet']['filecustomrules'] = nil
 
-# Timeout for the finalize stage of a fast external reparent reconciliation. (default 30s)
-default['vitess']['vttablet']['finalize_external_reparent_timeout'] = '30s'
-
 # Google Cloud Storage bucket to use for backups
 default['vitess']['vttablet']['gcs_backup_storage_bucket'] = nil
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 issues_url 'https://github.com/vinted/chef-vitess/issues'
 source_url 'https://github.com/vinted/chef-vitess'
 chef_version '>= 12.1' if respond_to?(:chef_version)
-version '4.3.2'
+version '4.3.3'
 
 supports 'redhat'
 supports 'centos'


### PR DESCRIPTION
- [FIX] `finalize_external_reparent_timeout` is no longer used with vttablet

@vinted/sre @tomas-didziokas @ernestas-poskus @ernestas-vinted