### PR TITLE
Fix/deprecate vtctld parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,3 +46,7 @@ Initial release.
 
 # 4.3.3
 - [FIX] `finalize_external_reparent_timeout` is no longer used with vttablet
+
+# 4.3.4
+- [FIX] `schema_swap_admin_query_timeout`, `schema_swap_backup_concurrency`, `schema_swap_delay_between_errors`, `schema_swap_reparent_timeout` are no longer used with vtctld
+

--- a/attributes/vtctld.rb
+++ b/attributes/vtctld.rb
@@ -290,20 +290,6 @@ default['vitess']['vtctld']['schema_change_slave_timeout'] = '10s'
 # The user who submits this schema change
 default['vitess']['vtctld']['schema_change_user'] = nil
 
-# timeout for SQL queries used to save and retrieve meta information for schema swap process (default
-# 30s)
-default['vitess']['vtctld']['schema_swap_admin_query_timeout'] = '30s'
-
-# number of simultaneous compression/checksum jobs to run for seed backup during schema swap (default
-# 4)
-default['vitess']['vtctld']['schema_swap_backup_concurrency'] = 4
-
-# time to wait after a retryable error happened in the schema swap process (default 1m0s)
-default['vitess']['vtctld']['schema_swap_delay_between_errors'] = '1m0s'
-
-# timeout to wait for slaves when doing reparent during schema swap (default 30s)
-default['vitess']['vtctld']['schema_swap_reparent_timeout'] = '30s'
-
 # the name of a registered security policy to use for controlling access to URLs - empty means allow
 # all for anyone (built-in policies: deny-all, read-only)
 default['vitess']['vtctld']['security_policy'] = nil

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 issues_url 'https://github.com/vinted/chef-vitess/issues'
 source_url 'https://github.com/vinted/chef-vitess'
 chef_version '>= 12.1' if respond_to?(:chef_version)
-version '4.3.3'
+version '4.3.4'
 
 supports 'redhat'
 supports 'centos'


### PR DESCRIPTION
- [FIX] `schema_swap_admin_query_timeout`,`schema_swap_backup_concurrency` `schema_swap_delay_between_errors` `schema_swap_reparent_timeout` are no longer used with vtctld

@vinted/sre @tomas-didziokas @ernestas-poskus @ernestas-vinted