### PR TITLE
Feature/init_dbsql_sql_postfix base resource attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,3 +50,5 @@ Initial release.
 # 4.3.4
 - [FIX] `schema_swap_admin_query_timeout`, `schema_swap_backup_concurrency`, `schema_swap_delay_between_errors`, `schema_swap_reparent_timeout` are no longer used with vtctld
 
+# 4.4.0
+- [FEATURE] base resource now includes `init_dbsql_sql_postfix` to enable having multiple `init_db.sql` files

--- a/libraries/base_service.rb
+++ b/libraries/base_service.rb
@@ -83,6 +83,7 @@ class Chef
       attribute(:mycnf, kind_of: Hash, default: lazy { node['vitess']['mycnf'] })
 
       # Cookbook
+      attribute(:init_dbsql_sql_postfix, kind_of: String, default: '')
       attribute(:init_dbsql_sql_cookbook, kind_of: String, default: 'vitess')
       attribute(:init_dbsql_sql_variables, kind_of: Hash, default: {})
     end
@@ -149,7 +150,7 @@ class Chef
       end
 
       def init_dbsql_path
-        @init_dbsql_path ||= "#{vt_config_path}/init_db.sql"
+        @init_dbsql_path ||= "#{vt_config_path}/init_db#{new_resource.init_dbsql_sql_postfix}.sql"
       end
 
       def install_init_dbsql

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 issues_url 'https://github.com/vinted/chef-vitess/issues'
 source_url 'https://github.com/vinted/chef-vitess'
 chef_version '>= 12.1' if respond_to?(:chef_version)
-version '4.3.4'
+version '4.4.0'
 
 supports 'redhat'
 supports 'centos'

--- a/test/integration/cluster/helpers.rb
+++ b/test/integration/cluster/helpers.rb
@@ -3,3 +3,7 @@ SERVICES = %w[
   vttablet0 vttablet1 vttablet2
   vtctld vtgate vtworker
 ]
+
+INIT_DB_SQL_FILES = %w[
+  init_dbmysqlctld0.sql init_dbmysqlctld1.sql init_dbmysqlctld2.sql
+]

--- a/test/integration/cluster/mysql_spec.rb
+++ b/test/integration/cluster/mysql_spec.rb
@@ -10,3 +10,11 @@
     it { should be_installed }
   end
 end
+
+INIT_DB_SQL_FILES.each do |init_db_file|
+  describe file("/var/lib/vt/config/#{init_db_file}") do
+    its('owner') { should eq 'vitess' }
+    its('group') { should eq 'vitess' }
+    it { should exist }
+  end
+end

--- a/test/integration/cookbooks/test-vitess/recipes/cluster.rb
+++ b/test/integration/cookbooks/test-vitess/recipes/cluster.rb
@@ -44,6 +44,7 @@ uids.each_with_index do |uid, index|
   mysqlctld_service "mysqlctld instance #{index}" do
     args mysqlctld
     service_name "mysqlctld#{index}"
+    init_dbsql_sql_postfix "mysqlctld#{index}"
   end
 end
 


### PR DESCRIPTION
* [FEATURE] base resource now includes `init_dbsql_sql_postfix` to enable having multiple `init_db.sql` files

@vinted/sre @tomas-didziokas @ernestas-poskus @ernestas-vinted