### PR TITLE
Feature/add afe46d8 release support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,3 +52,6 @@ Initial release.
 
 # 4.4.0
 - [FEATURE] base resource now includes `init_dbsql_sql_postfix` to enable having multiple `init_db.sql` files
+
+# 4.5.0
+- [CHANGE] Removed old 6.0 releases. Added support for afe46d8 (2020-06-10) release with fixed autocommit

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -8,16 +8,16 @@ default['vitess']['topo_global_server_address'] = 'localhost:2379'
 # the topology implementation to use
 default['vitess']['topo_implementation'] = 'etcd2'
 
-default['vitess']['version']['mysqlctld'] = 'v6.0-41c356e'
-default['vitess']['version']['vtctlclient'] = 'v6.0-41c356e'
-default['vitess']['version']['vtctld'] = 'v6.0-41c356e'
-default['vitess']['version']['vtgate'] = 'v6.0-41c356e'
-default['vitess']['version']['vttablet'] = 'v6.0-41c356e'
-default['vitess']['version']['vtworker'] = 'v6.0-41c356e'
-default['vitess']['version']['mysqlctl'] = 'v6.0-41c356e'
-default['vitess']['version']['vtctl'] = 'v6.0-41c356e'
-default['vitess']['version']['vtexplain'] = 'v6.0-41c356e'
-default['vitess']['version']['vtbench'] = 'v6.0-41c356e'
+default['vitess']['version']['mysqlctld'] = 'v6.0-afe46d8'
+default['vitess']['version']['vtctlclient'] = 'v6.0-afe46d8'
+default['vitess']['version']['vtctld'] = 'v6.0-afe46d8'
+default['vitess']['version']['vtgate'] = 'v6.0-afe46d8'
+default['vitess']['version']['vttablet'] = 'v6.0-afe46d8'
+default['vitess']['version']['vtworker'] = 'v6.0-afe46d8'
+default['vitess']['version']['mysqlctl'] = 'v6.0-afe46d8'
+default['vitess']['version']['vtctl'] = 'v6.0-afe46d8'
+default['vitess']['version']['vtexplain'] = 'v6.0-afe46d8'
+default['vitess']['version']['vtbench'] = 'v6.0-afe46d8'
 
 # host to send spans to. if empty, no tracing will be done
 default['vitess']['datadog-agent-host'] = nil

--- a/attributes/releases.rb
+++ b/attributes/releases.rb
@@ -1,17 +1,5 @@
-# 20-05-01 at 09:59:07 PM UTC
-default['vitess']['releases']['9fe7fd3']['url'] =
-  'https://github.com/planetscale/vitess-releases/releases/download/9fe7fd3/vitess-6.0-9fe7fd3.tar.gz'
-default['vitess']['releases']['9fe7fd3']['checksum'] =
-  'c69fba47b364b4eea75b0bff478777764b627dbcd836f723397f306673fe269b'
-
-# 2020-05-14 at 08:44:13 PM UTC
-default['vitess']['releases']['25db221']['url'] =
-  'https://github.com/planetscale/vitess-releases/releases/download/25db221/vitess-6.0-25db221.tar.gz'
-default['vitess']['releases']['25db221']['checksum'] =
-  'b8c1ac3b7f9ed41d544a22cb63bfd213e1e5812f6d427fb16c8c485b6ad13953'
-
-# 2020-06-04 at 12:01:01 AM UTC
-default['vitess']['releases']['41c356e']['url'] =
-  'https://github.com/planetscale/vitess-releases/releases/download/41c356e/vitess-6.0-41c356e.tar.gz'
-default['vitess']['releases']['41c356e']['checksum'] =
-  '3bda4eeb3237b1f73b6c4e207372ec8aec9a855ec640f7300c172d20bca382b9'
+# 2020-06-10 at 11:45:51 PM UTC
+default['vitess']['releases']['afe46d8']['url'] =
+  'https://github.com/planetscale/vitess-releases/releases/download/afe46d8/vitess-6.0-afe46d8.tar.gz'
+default['vitess']['releases']['afe46d8']['checksum'] =
+  '01f996ce81d0f17768de4fa8c2405c0625312a5b4abc0940d5892a847be0efaa'

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 issues_url 'https://github.com/vinted/chef-vitess/issues'
 source_url 'https://github.com/vinted/chef-vitess'
 chef_version '>= 12.1' if respond_to?(:chef_version)
-version '4.4.0'
+version '4.5.0'
 
 supports 'redhat'
 supports 'centos'


### PR DESCRIPTION
- [CHANGE] Removed old 6.0 releases. Added support for afe46d8 (2020-06-10) release with fixed autocommit

@vinted/sre @tomas-didziokas @ernestas-poskus @ernestas-vinted
