### PR TITLE
Add bbfe181 release support with regression fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,3 +55,6 @@ Initial release.
 
 # 4.5.0
 - [CHANGE] Removed old 6.0 releases. Added support for afe46d8 (2020-06-10) release with fixed autocommit
+
+# 4.6.0
+- [CHANGE] Removed old 6.0 releases. Added support for bbfe181 (2020-06-25) release

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -8,16 +8,16 @@ default['vitess']['topo_global_server_address'] = 'localhost:2379'
 # the topology implementation to use
 default['vitess']['topo_implementation'] = 'etcd2'
 
-default['vitess']['version']['mysqlctld'] = 'v6.0-afe46d8'
-default['vitess']['version']['vtctlclient'] = 'v6.0-afe46d8'
-default['vitess']['version']['vtctld'] = 'v6.0-afe46d8'
-default['vitess']['version']['vtgate'] = 'v6.0-afe46d8'
-default['vitess']['version']['vttablet'] = 'v6.0-afe46d8'
-default['vitess']['version']['vtworker'] = 'v6.0-afe46d8'
-default['vitess']['version']['mysqlctl'] = 'v6.0-afe46d8'
-default['vitess']['version']['vtctl'] = 'v6.0-afe46d8'
-default['vitess']['version']['vtexplain'] = 'v6.0-afe46d8'
-default['vitess']['version']['vtbench'] = 'v6.0-afe46d8'
+default['vitess']['version']['mysqlctld'] = 'v6.0-bbfe181'
+default['vitess']['version']['vtctlclient'] = 'v6.0-bbfe181'
+default['vitess']['version']['vtctld'] = 'v6.0-bbfe181'
+default['vitess']['version']['vtgate'] = 'v6.0-bbfe181'
+default['vitess']['version']['vttablet'] = 'v6.0-bbfe181'
+default['vitess']['version']['vtworker'] = 'v6.0-bbfe181'
+default['vitess']['version']['mysqlctl'] = 'v6.0-bbfe181'
+default['vitess']['version']['vtctl'] = 'v6.0-bbfe181'
+default['vitess']['version']['vtexplain'] = 'v6.0-bbfe181'
+default['vitess']['version']['vtbench'] = 'v6.0-bbfe181'
 
 # host to send spans to. if empty, no tracing will be done
 default['vitess']['datadog-agent-host'] = nil

--- a/attributes/releases.rb
+++ b/attributes/releases.rb
@@ -1,5 +1,5 @@
-# 2020-06-10 at 11:45:51 PM UTC
-default['vitess']['releases']['afe46d8']['url'] =
-  'https://github.com/planetscale/vitess-releases/releases/download/afe46d8/vitess-6.0-afe46d8.tar.gz'
-default['vitess']['releases']['afe46d8']['checksum'] =
-  '01f996ce81d0f17768de4fa8c2405c0625312a5b4abc0940d5892a847be0efaa'
+# 2020-06-25 at 02:36:48 AM UTC
+default['vitess']['releases']['bbfe181']['url'] =
+  'https://github.com/planetscale/vitess-releases/releases/download/bbfe181/vitess-6.0-bbfe181.tar.gz'
+default['vitess']['releases']['bbfe181']['checksum'] =
+  '40af3aff20234f1fbbe212c131cb8170547f775b33e6909fa93ec7458d44f697'

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 issues_url 'https://github.com/vinted/chef-vitess/issues'
 source_url 'https://github.com/vinted/chef-vitess'
 chef_version '>= 12.1' if respond_to?(:chef_version)
-version '4.5.0'
+version '4.6.0'
 
 supports 'redhat'
 supports 'centos'


### PR DESCRIPTION
- [CHANGE] Removed old 6.0 releases. Added support for bbfe181 (2020-06-25) release

this version includes a number of regression fixes:

- https://github.com/vitessio/vitess/releases/tag/v6.0.20-20200624
- https://github.com/vitessio/vitess/releases/tag/v6.0.20-20200617

@vinted/sre @tomas-didziokas @ernestas-poskus @ernestas-vinted