### PR TITLE
Add b3294e8 release support 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,3 +58,6 @@ Initial release.
 
 # 4.6.0
 - [CHANGE] Removed old 6.0 releases. Added support for bbfe181 (2020-06-25) release
+
+# 4.7.0
+- [CHANGE] Removed old 6.0 releases. Added support for b3294e8 (2020-18-17) release with 7.0.0 vitess

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -8,16 +8,16 @@ default['vitess']['topo_global_server_address'] = 'localhost:2379'
 # the topology implementation to use
 default['vitess']['topo_implementation'] = 'etcd2'
 
-default['vitess']['version']['mysqlctld'] = 'v6.0-bbfe181'
-default['vitess']['version']['vtctlclient'] = 'v6.0-bbfe181'
-default['vitess']['version']['vtctld'] = 'v6.0-bbfe181'
-default['vitess']['version']['vtgate'] = 'v6.0-bbfe181'
-default['vitess']['version']['vttablet'] = 'v6.0-bbfe181'
-default['vitess']['version']['vtworker'] = 'v6.0-bbfe181'
-default['vitess']['version']['mysqlctl'] = 'v6.0-bbfe181'
-default['vitess']['version']['vtctl'] = 'v6.0-bbfe181'
-default['vitess']['version']['vtexplain'] = 'v6.0-bbfe181'
-default['vitess']['version']['vtbench'] = 'v6.0-bbfe181'
+default['vitess']['version']['mysqlctld'] = 'v7.0.0-b3294e8'
+default['vitess']['version']['vtctlclient'] = 'v7.0.0-b3294e8'
+default['vitess']['version']['vtctld'] = 'v7.0.0-b3294e8'
+default['vitess']['version']['vtgate'] = 'v7.0.0-b3294e8'
+default['vitess']['version']['vttablet'] = 'v7.0.0-b3294e8'
+default['vitess']['version']['vtworker'] = 'v7.0.0-b3294e8'
+default['vitess']['version']['mysqlctl'] = 'v7.0.0-b3294e8'
+default['vitess']['version']['vtctl'] = 'v7.0.0-b3294e8'
+default['vitess']['version']['vtexplain'] = 'v7.0.0-b3294e8'
+default['vitess']['version']['vtbench'] = 'v7.0.0-b3294e8'
 
 # host to send spans to. if empty, no tracing will be done
 default['vitess']['datadog-agent-host'] = nil

--- a/attributes/mycnf.rb
+++ b/attributes/mycnf.rb
@@ -49,7 +49,6 @@ default['vitess']['mycnf']['default'] = {
   # the master.
   'skip_slave_start' => nil,
   'slave_net_timeout' => 60,
-  'slave_load_tmpdir' => '{{.SlaveLoadTmpDir}}',
   'slow-query-log' => nil,
   'slow-query-log-file' => '{{.SlowLogPath}}',
   'socket' => '{{.SocketFile}}',

--- a/attributes/releases.rb
+++ b/attributes/releases.rb
@@ -1,5 +1,5 @@
-# 2020-06-25 at 02:36:48 AM UTC
-default['vitess']['releases']['bbfe181']['url'] =
-  'https://github.com/planetscale/vitess-releases/releases/download/bbfe181/vitess-6.0-bbfe181.tar.gz'
-default['vitess']['releases']['bbfe181']['checksum'] =
-  '40af3aff20234f1fbbe212c131cb8170547f775b33e6909fa93ec7458d44f697'
+# 2020-08-17 at 11:14:02 AM UTC
+default['vitess']['releases']['b3294e8']['url'] =
+  'https://github.com/vinted/vitess-binary-files/releases/download/b3294e8/vitess-7.0.0-b3294e8.tar.gz'
+default['vitess']['releases']['b3294e8']['checksum'] =
+  '7d69259c92bd461dd512a6779ea52570fac3e3279798ce88fdcf263fb24c8634'

--- a/attributes/vtctld.rb
+++ b/attributes/vtctld.rb
@@ -285,7 +285,7 @@ default['vitess']['vtctld']['schema_change_controller'] = nil
 default['vitess']['vtctld']['schema_change_dir'] = nil
 
 # how long to wait for slaves to receive the schema change (default 10s)
-default['vitess']['vtctld']['schema_change_slave_timeout'] = '10s'
+default['vitess']['vtctld']['schema_change_replicas_timeout'] = '10s'
 
 # The user who submits this schema change
 default['vitess']['vtctld']['schema_change_user'] = nil

--- a/attributes/vtgate.rb
+++ b/attributes/vtgate.rb
@@ -61,8 +61,8 @@ default['vitess']['vtgate']['enable_buffer_dry_run'] = nil
 # controls the capacity of the lru cache. (default 10000)
 default['vitess']['vtgate']['gate_query_cache_size'] = 10_000
 
-# The implementation of gateway (default "discoverygateway")
-default['vitess']['vtgate']['gateway_implementation'] = 'discoverygateway'
+# The implementation of gateway (default "tabletgateway")
+default['vitess']['vtgate']['gateway_implementation'] = 'tabletgateway'
 
 # At startup, the gateway will wait up to that duration to get one tablet per
 # keyspace/shard/tablettype (default 30s)

--- a/attributes/vttablet.rb
+++ b/attributes/vttablet.rb
@@ -650,9 +650,6 @@ default['vitess']['vttablet']['mycnf_relay_log_path'] = nil
 # mysql server id of the server (if specified, mycnf-file will be ignored)
 default['vitess']['vttablet']['mycnf_server_id'] = nil
 
-# slave load tmp directory
-default['vitess']['vttablet']['mycnf_slave_load_tmp_dir'] = nil
-
 # mysql slow query log path
 default['vitess']['vttablet']['mycnf_slow_log_path'] = nil
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 issues_url 'https://github.com/vinted/chef-vitess/issues'
 source_url 'https://github.com/vinted/chef-vitess'
 chef_version '>= 12.1' if respond_to?(:chef_version)
-version '4.6.0'
+version '4.7.0'
 
 supports 'redhat'
 supports 'centos'


### PR DESCRIPTION
- [CHANGE] Removed old 6.0 releases. Added support for b3294e8 (2020-18-17) release with 7.0.0 vitess

[Vitess 7.0.0 release](https://github.com/vitessio/vitess/releases/tag/v7.0.0)

@vinted/sre @tomas-didziokas @ernestas-poskus @ernestas-vinted