### PR TITLE
Add 40ee160 release support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,3 +61,8 @@ Initial release.
 
 # 4.7.0
 - [CHANGE] Removed old 6.0 releases. Added support for b3294e8 (2020-18-17) release with 7.0.0 vitess
+
+# 4.8.0
+- [CHANGE] Added support for 40ee160 (2020-09-22) release with pre 7.0.2 vitess
+- [CHANGE] Switch default release to 40ee160
+- [CHANGE] `grpc_server_keepalive_enforcement_policy_min_time` default changed

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -8,16 +8,16 @@ default['vitess']['topo_global_server_address'] = 'localhost:2379'
 # the topology implementation to use
 default['vitess']['topo_implementation'] = 'etcd2'
 
-default['vitess']['version']['mysqlctld'] = 'v7.0.0-b3294e8'
-default['vitess']['version']['vtctlclient'] = 'v7.0.0-b3294e8'
-default['vitess']['version']['vtctld'] = 'v7.0.0-b3294e8'
-default['vitess']['version']['vtgate'] = 'v7.0.0-b3294e8'
-default['vitess']['version']['vttablet'] = 'v7.0.0-b3294e8'
-default['vitess']['version']['vtworker'] = 'v7.0.0-b3294e8'
-default['vitess']['version']['mysqlctl'] = 'v7.0.0-b3294e8'
-default['vitess']['version']['vtctl'] = 'v7.0.0-b3294e8'
-default['vitess']['version']['vtexplain'] = 'v7.0.0-b3294e8'
-default['vitess']['version']['vtbench'] = 'v7.0.0-b3294e8'
+default['vitess']['version']['mysqlctld'] = 'v7.0.2-40ee160'
+default['vitess']['version']['vtctlclient'] = 'v7.0.2-40ee160'
+default['vitess']['version']['vtctld'] = 'v7.0.2-40ee160'
+default['vitess']['version']['vtgate'] = 'v7.0.2-40ee160'
+default['vitess']['version']['vttablet'] = 'v7.0.2-40ee160'
+default['vitess']['version']['vtworker'] = 'v7.0.2-40ee160'
+default['vitess']['version']['mysqlctl'] = 'v7.0.2-40ee160'
+default['vitess']['version']['vtctl'] = 'v7.0.2-40ee160'
+default['vitess']['version']['vtexplain'] = 'v7.0.2-40ee160'
+default['vitess']['version']['vtbench'] = 'v7.0.2-40ee160'
 
 # host to send spans to. if empty, no tracing will be done
 default['vitess']['datadog-agent-host'] = nil

--- a/attributes/mysqlctld.rb
+++ b/attributes/mysqlctld.rb
@@ -192,7 +192,7 @@ default['vitess']['mysqlctld']['grpc_server_initial_conn_window_size'] = nil
 default['vitess']['mysqlctld']['grpc_server_initial_window_size'] = nil
 
 # grpc server minimum keepalive time (default 5m0s)
-default['vitess']['mysqlctld']['grpc_server_keepalive_enforcement_policy_min_time'] = '5m0s'
+default['vitess']['mysqlctld']['grpc_server_keepalive_enforcement_policy_min_time'] = '10s'
 
 # grpc server permit client keepalive pings even when there are no active streams (RPCs)
 default['vitess']['mysqlctld']['grpc_server_keepalive_enforcement_policy_permit_without_stream'] = nil

--- a/attributes/releases.rb
+++ b/attributes/releases.rb
@@ -3,3 +3,8 @@ default['vitess']['releases']['b3294e8']['url'] =
   'https://github.com/vinted/vitess-binary-files/releases/download/b3294e8/vitess-7.0.0-b3294e8.tar.gz'
 default['vitess']['releases']['b3294e8']['checksum'] =
   '7d69259c92bd461dd512a6779ea52570fac3e3279798ce88fdcf263fb24c8634'
+# 2020-09-22 at 09:20:15 UTC
+default['vitess']['releases']['40ee160']['url'] =
+  'https://github.com/vinted/vitess-binary-files/releases/download/40ee160/vitess-7.0.2-40ee160.tar.gz'
+default['vitess']['releases']['40ee160']['checksum'] =
+  '232939eb3cbef27d126bd287e0598504403fcc70fc374210f8c8461864656a34'

--- a/attributes/vtctld.rb
+++ b/attributes/vtctld.rb
@@ -153,7 +153,7 @@ default['vitess']['vtctld']['grpc_server_initial_conn_window_size'] = nil
 default['vitess']['vtctld']['grpc_server_initial_window_size'] = nil
 
 # grpc server minimum keepalive time (default 5m0s)
-default['vitess']['vtctld']['grpc_server_keepalive_enforcement_policy_min_time'] = '5m0s'
+default['vitess']['vtctld']['grpc_server_keepalive_enforcement_policy_min_time'] = '10s'
 
 # grpc server permit client keepalive pings even when there are no active streams (RPCs)
 default['vitess']['vtctld']['grpc_server_keepalive_enforcement_policy_permit_without_stream'] = nil

--- a/attributes/vtgate.rb
+++ b/attributes/vtgate.rb
@@ -131,7 +131,7 @@ default['vitess']['vtgate']['grpc_server_initial_conn_window_size'] = nil
 default['vitess']['vtgate']['grpc_server_initial_window_size'] = nil
 
 # grpc server minimum keepalive time (default 5m0s)
-default['vitess']['vtgate']['grpc_server_keepalive_enforcement_policy_min_time'] = '5m0s'
+default['vitess']['vtgate']['grpc_server_keepalive_enforcement_policy_min_time'] = '10s'
 
 # grpc server permit client keepalive pings even when there are no active streams (RPCs)
 default['vitess']['vtgate']['grpc_server_keepalive_enforcement_policy_permit_without_stream'] = nil

--- a/attributes/vttablet.rb
+++ b/attributes/vttablet.rb
@@ -504,7 +504,7 @@ default['vitess']['vttablet']['grpc_server_initial_conn_window_size'] = nil
 default['vitess']['vttablet']['grpc_server_initial_window_size'] = nil
 
 # grpc server minimum keepalive time (default 5m0s)
-default['vitess']['vttablet']['grpc_server_keepalive_enforcement_policy_min_time'] = '5m0s'
+default['vitess']['vttablet']['grpc_server_keepalive_enforcement_policy_min_time'] = '10s'
 
 # grpc server permit client keepalive pings even when there are no active streams (RPCs)
 default['vitess']['vttablet']['grpc_server_keepalive_enforcement_policy_permit_without_stream'] = nil

--- a/attributes/vtworker.rb
+++ b/attributes/vtworker.rb
@@ -137,7 +137,7 @@ default['vitess']['vtworker']['grpc_server_initial_conn_window_size'] = nil
 default['vitess']['vtworker']['grpc_server_initial_window_size'] = nil
 
 # grpc server minimum keepalive time (default 5m0s)
-default['vitess']['vtworker']['grpc_server_keepalive_enforcement_policy_min_time'] = '5m0s'
+default['vitess']['vtworker']['grpc_server_keepalive_enforcement_policy_min_time'] = '10s'
 
 # grpc server permit client keepalive pings even when there are no active streams (RPCs)
 default['vitess']['vtworker']['grpc_server_keepalive_enforcement_policy_permit_without_stream'] = nil

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 issues_url 'https://github.com/vinted/chef-vitess/issues'
 source_url 'https://github.com/vinted/chef-vitess'
 chef_version '>= 12.1' if respond_to?(:chef_version)
-version '4.7.0'
+version '4.8.0'
 
 supports 'redhat'
 supports 'centos'


### PR DESCRIPTION
# 4.8.0
- [CHANGE] Added support for 40ee160 (2020-09-22) release with pre 7.0.2 vitess
- [CHANGE] Switch default release to 40ee160
- [CHANGE] `grpc_server_keepalive_enforcement_policy_min_time` default changed

@vinted/sre @tomas-didziokas