### PR TITLE
Use exec in service wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,3 +73,4 @@ Initial release.
 
 # 4.10.0
 - [CHANGE] Use `exec` in service bash wrapper
+- [CHANGE] Lock json gem to v2.4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,3 +70,6 @@ Initial release.
 # 4.9.0
 - [CHANGE] Added support for c02b7d5 (2020-09-24) release with 7.0.2 vitess
 - [CHANGE] Switch default release to c02b7d5
+
+# 4.10.0
+- [CHANGE] Use `exec` in service bash wrapper

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ group :unit do
 end
 
 group :kitchen_common do
+  gem 'json', '<=2.4.1'
   gem 'kitchen-docker'
   gem 'kitchen-inspec', '<= 1.3.1'
   gem 'test-kitchen'

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,5 +1,4 @@
-Testing chef-vitess
-======================================
+# Testing chef-vitess
 
 This cookbook is equipped with both unit tests (chefspec) and integration tests
 (test-kitchen and serverspec). Contributions to this cookbook should include tests
@@ -22,3 +21,19 @@ $ bundle exec kitchen destroy
 The final destroy is intended to clean up any systems that failed a test, and is
 mostly useful when running with kitchen drivers for cloud providers, so that no
 machines are left orphaned and costing you money.
+
+## Possible problems
+
+If kitchen fails and you see this in the logs:
+
+```text
+------Exception-------
+Class: Kitchen::ActionFailed
+Message: Could not parse Docker build output for image ID
+```
+
+Disable BuildKit:
+
+```bash
+export DOCKER_BUILDKIT=0
+```

--- a/libraries/base_service.rb
+++ b/libraries/base_service.rb
@@ -318,7 +318,7 @@ class Chef
       # rubocop:disable Metrics/MethodLength
       # rubocop:disable Metrics/AbcSize
       def install_service
-        cmd = "#{bin_location} \\\n #{service_args}"
+        cmd = "exec #{bin_location} \\\n #{service_args}"
         service_name = new_resource.service_name
         exec_start = ::File.join(vt_bin_path, "#{service_name}.sh")
         env = vitess_environment

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 issues_url 'https://github.com/vinted/chef-vitess/issues'
 source_url 'https://github.com/vinted/chef-vitess'
 chef_version '>= 12.1' if respond_to?(:chef_version)
-version '4.9.0'
+version '4.10.0'
 
 supports 'redhat'
 supports 'centos'

--- a/test/integration/shellwrapper/service_spec.rb
+++ b/test/integration/shellwrapper/service_spec.rb
@@ -1,0 +1,29 @@
+describe file('/var/lib/vt/bin/mysqlctld0.sh') do
+  its('owner') { should eq 'vitess' }
+  its('group') { should eq 'vitess' }
+  its('mode') { should cmp '0750' }
+  it { should exist }
+
+  its('content') { should match '#!/bin/sh' }
+  its('content') { should match 'exec /usr/local/bin/mysqlctld' }
+end
+
+describe file('/var/lib/vt/bin/vtgate.sh') do
+  its('owner') { should eq 'vitess' }
+  its('group') { should eq 'vitess' }
+  its('mode') { should cmp '0750' }
+  it { should exist }
+
+  its('content') { should match '#!/bin/sh' }
+  its('content') { should match 'exec /usr/local/bin/vtgate' }
+end
+
+describe file('/var/lib/vt/bin/vttablet0.sh') do
+  its('owner') { should eq 'vitess' }
+  its('group') { should eq 'vitess' }
+  its('mode') { should cmp '0750' }
+  it { should exist }
+
+  its('content') { should match '#!/bin/sh' }
+  its('content') { should match 'exec /usr/local/bin/vttablet' }
+end

--- a/test/integration/shellwrapper/shell_spec.rb
+++ b/test/integration/shellwrapper/shell_spec.rb
@@ -7,6 +7,7 @@ describe file('/usr/local/bin/vtctl-ApplySchema') do
   its('content') { should match '#!/bin/sh' }
   its('content') { should match 'VTROOT=/var/lib/vt VTDATAROOT=/var/lib/vtdataroot MYSQL_FLAVOR=master_percona57 VT_MYSQL_ROOT=/ KITCHEN=1' }
   its('content') { should match '/usr/local/bin/vtctl' }
+  its('content') { should_not match 'exec ' }
 end
 
 describe file('/usr/local/bin/vtctlclient-client') do
@@ -17,6 +18,7 @@ describe file('/usr/local/bin/vtctlclient-client') do
 
   its('content') { should match '#!/bin/sh' }
   its('content') { should match 'VTROOT=/var/lib/vt VTDATAROOT=/var/lib/vtdataroot MYSQL_FLAVOR=master_percona57 VT_MYSQL_ROOT=/ CLIENT=1 /usr/local/bin/vtctlclient vtctlclient' }
+  its('content') { should_not match 'exec ' }
 end
 
 describe file('/usr/local/bin/mysqlctl-client') do
@@ -27,4 +29,5 @@ describe file('/usr/local/bin/mysqlctl-client') do
 
   its('content') { should match '#!/bin/sh' }
   its('content') { should match 'VTROOT=/var/lib/vt VTDATAROOT=/var/lib/vtdataroot MYSQL_FLAVOR=master_percona57 VT_MYSQL_ROOT=/ CL=1 /usr/local/bin/mysqlctl mysqlctl' }
+  its('content') { should_not match 'exec ' }
 end


### PR DESCRIPTION
This PR adds `exec` to the service wrapper bash script. From `man bash`:
```
exec [-cl] [-a name] [command [arguments]]
      If command is specified, it replaces the shell.  No new  process
      is  created.  The arguments become the arguments to command.
      ...
```

Adding `exec` is OK because the service wrapper script is a one-liner. The positive effect of this change is that there will be no bash process in systemd service process list any more. This bash process serves no purpose and might confuse systemd when sending signals to subprocesses. For example, compare the subprocess tree before the change:

```
systemctl status  mysqlctld0.service
● mysqlctld0.service - Chef managed mysqlctld0 service
   Loaded: loaded (/etc/systemd/system/mysqlctld0.service; enabled; vendor preset: disabled)
   Active: active (running) since Wed 2020-12-16 10:14:22 UTC; 8s ago
 Main PID: 6108 (mysqlctld0.sh)
   CGroup: /docker/66456e4130f019bcadfab774598500abd7bda90933b686bffdb7558344275d19/system.slice/mysqlctld0.service
           ├─6108 /bin/sh /var/lib/vt/bin/mysqlctld0.sh     <--- wrapper script as main PID
           ├─6109 /usr/local/bin/mysqlctld ...
           └─6120 /sbin/mysqld ....
```

and after:

```
systemctl status  mysqlctld0.service
● mysqlctld0.service - Chef managed mysqlctld0 service
...
 Main PID: 6030 (mysqlctld)
   CGroup: /docker/66456e4130f019bcadfab774598500abd7bda90933b686bffdb7558344275d19/system.slice/mysqlctld0.service
           ├─6030 /usr/local/bin/mysqlctld -alsologtostderr=1 -app_idle_timeout=1m0s -app_pool_size=40 -backup_engine_implementation=builtin -backup_stor...
           └─6043 /sbin/mysqld --defaults-file=/var/lib/vtdataroot/vt_0000030000/my.cnf --basedir=/
```

This change also allows systemd to capture service logs. For example, logs before:

```
$ systemctl stop mysqlctld0

Dec 16 09:43:19 66456e4130f0 systemd[1]: Stopping Chef managed mysqlctld0 service...    <--- 5s wait starts
Dec 16 09:43:24 66456e4130f0 systemd[1]: mysqlctld0.service stop-final-sigterm timed out. Killing.     <--- force kill
Dec 16 09:43:24 66456e4130f0 systemd[1]: Stopped Chef managed mysqlctld0 service.
Dec 16 09:43:24 66456e4130f0 systemd[1]: Unit mysqlctld0.service entered failed state.
Dec 16 09:43:24 66456e4130f0 systemd[1]: mysqlctld0.service failed.
```

and after:

```
$ systemctl stop mysqlctld0

Dec 16 09:44:26 66456e4130f0 systemd[1]: Stopping Chef managed mysqlctld0 service...    <--- 5s wait starts    
Dec 16 09:44:26 66456e4130f0 mysqlctld0.sh[5842]: I1216 09:44:26.876362    5842 run.go:53] Entering lameduck mode for at least 50ms
Dec 16 09:44:26 66456e4130f0 mysqlctld0.sh[5842]: I1216 09:44:26.876435    5842 run.go:54] Firing asynchronous OnTerm hooks
Dec 16 09:44:26 66456e4130f0 mysqlctld0.sh[5842]: I1216 09:44:26.876535    5842 servenv.go:177] Firing synchronous OnTermSync hooks and waiting up to 10s for them
Dec 16 09:44:26 66456e4130f0 mysqlctld0.sh[5842]: I1216 09:44:26.876678    5842 grpc_server.go:232] Initiated graceful stop of gRPC server
Dec 16 09:44:26 66456e4130f0 mysqlctld0.sh[5842]: I1216 09:44:26.876934    5842 mysqlctld.go:124] mysqlctl received SIGTERM, shutting down mysqld first
Dec 16 09:44:26 66456e4130f0 mysqlctld0.sh[5842]: I1216 09:44:26.876964    5842 mysqld.go:483] Mysqld.Shutdown
Dec 16 09:44:26 66456e4130f0 mysqlctld0.sh[5842]: I1216 09:44:26.877030    5842 mysqld.go:521] No mysqld_shutdown hook, running mysqladmin directly
Dec 16 09:44:26 66456e4130f0 mysqlctld0.sh[5842]: I1216 09:44:26.877530    5842 mysqld.go:587] execCmd: /bin/mysqladmin /bin/mysqladmin [--defaults-extra-file=...
Dec 16 09:44:26 66456e4130f0 mysqlctld0.sh[5842]: I1216 09:44:26.878692    5842 grpc_server.go:234] gRPC server stopped
Dec 16 09:44:31 66456e4130f0 mysqlctld0.sh[5842]: I1216 09:44:31.365732    5842 mysqld.go:414] Mysqld.Start(1608111804) exit: <nil>
Dec 16 09:44:31 66456e4130f0 systemd[1]: mysqlctld0.service stop-sigterm timed out. Killing.     <--- force kill
Dec 16 09:44:31 66456e4130f0 systemd[1]: mysqlctld0.service: main process exited, code=killed, status=9/KILL
Dec 16 09:44:31 66456e4130f0 systemd[1]: Stopped Chef managed mysqlctld0 service.
Dec 16 09:44:31 66456e4130f0 systemd[1]: Unit mysqlctld0.service entered failed state.
Dec 16 09:44:31 66456e4130f0 systemd[1]: mysqlctld0.service failed.
```

This was tested with kitchen in this cookbook and in the dependent private vinted-vitess cookbook.