### PR TITLE
Add support for ecc245eed3 (2024-04-25) release with 11.0.4 Vitess andd fixes/backports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,3 +99,6 @@ Initial release.
 
 # 5.5.0
 - [CHANGE] Added support for 5d8fa9a (2023-09-22) release with 11.0.4 Vitess and fixes/backports
+
+# 5.6.0
+- [CHANGE] Added support for ecc245eed3 (2024-04-25) release with 11.0.4 Vitess and fixes/backports

--- a/attributes/releases.rb
+++ b/attributes/releases.rb
@@ -43,3 +43,8 @@ default['vitess']['releases']['5d8fa9a']['url'] =
   'https://github.com/vinted/vitess-binary-files/releases/download/11.0.4-patch10-5d8fa9a/vitess-11.0.4-patch10-5d8fa9a.tar.gz'
 default['vitess']['releases']['5d8fa9a']['checksum'] =
   '63128c094d12bae702a50e1eb483a7c03bbee72e19796a885613cb24ed243f1d'
+
+default['vitess']['releases']['ecc245eed3']['url'] =
+  'https://github.com/vinted/vitess-binary-files/releases/download/11.0.4-patch12-ecc245eed3/vitess-11.0.4-patch12-ecc245eed3.tar.gz'
+default['vitess']['releases']['ecc245eed3']['checksum'] =
+  'c75e9627d153f06d3bac4ade7d0497aba9cb2a5d3386be527c98a6e7e6371411'

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description 'Installs/Configures Vitess database clustering system.'
 issues_url 'https://github.com/vinted/chef-vitess/issues'
 source_url 'https://github.com/vinted/chef-vitess'
 chef_version '>= 15.5'
-version '5.5.0'
+version '5.6.0'
 
 supports 'redhat'
 supports 'centos'


### PR DESCRIPTION
Add support for ecc245eed3 (2024-04-25) release with 11.0.4 patch 12

https://github.com/vinted/vitess-binary-files/releases/tag/11.0.4-patch12-ecc245eed3